### PR TITLE
Add example scripts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ This project follows the guidelines of `Keep a changelog`_ and adheres to
 .. _Keep a changelog: http://keepachangelog.com/
 .. _Semantic versioning: https://semver.org/
 
+Unreleased
+==========
+
+Added
+-----
+* Add example scripts for the signal generator and oscilloscope functionalities.
+
 `1.2.0`_ 2024-07-22
 ===================
 

--- a/examples/generator_burst.py
+++ b/examples/generator_burst.py
@@ -1,24 +1,27 @@
-"""This Module demonstrates the burst count mode of the signal generator.
+"""This module demonstrates the burst count mode of the signal generator.
 
 When the generator is started the generator generates a specified number of
 periods of the selected signal. When the required number of periods is reached,
 the generator stops automatically and the output will go to the selected
-Offset. In order to visualize the generated signal you need to connect the
+offset. In order to visualize the generated signal you need to connect the
 output of the handyscope with an input from an external oscilloscope.
 """
-from handyscope import Generator
 import time
+
+from handyscope import Generator
+
 
 gen = Generator("HS5")  # Initialize HS5 generator device
 
 gen.mode = "burst count"
 gen.signal_type = "sine"
 gen.amplitude = 2  # 2 V
-gen.freq = 1e6  # 1e6 Hz
+gen.freq = 50  # 50 Hz
 gen.offset = 1  # 1 V
-gen.burst_cnt = int(5e6)  # Duration of signal is equivalent to 5 seconds
+gen.burst_cnt = 10  # Duration of signal is equivalent to 0.2 seconds
 
 gen.is_out_on = True
 
 gen.start()
-time.sleep(10)  # Wait 10 seconds before python script terminates
+# Output offset for another 0.5 seconds by keeping python script running
+time.sleep(0.5)

--- a/examples/generator_burst.py
+++ b/examples/generator_burst.py
@@ -1,0 +1,24 @@
+"""This Module demonstrates the burst count mode of the signal generator.
+
+When the generator is started the generator generates a specified number of
+periods of the selected signal. When the required number of periods is reached,
+the generator stops automatically and the output will go to the selected
+Offset. In order to visualize the generated signal you need to connect the
+output of the handyscope with an input from an external oscilloscope.
+"""
+from handyscope import Generator
+import time
+
+gen = Generator("HS5")  # Initialize HS5 generator device
+
+gen.mode = "burst count"
+gen.signal_type = "sine"
+gen.amplitude = 2  # 2 V
+gen.freq = 1e6  # 1e6 Hz
+gen.offset = 1  # 1 V
+gen.burst_cnt = int(5e6)  # Duration of signal is equivalent to 5 seconds
+
+gen.is_out_on = True
+
+gen.start()
+time.sleep(10)  # Wait 10 seconds before python script terminates

--- a/examples/generator_continuous.py
+++ b/examples/generator_continuous.py
@@ -1,28 +1,31 @@
-"""This Module demonstrates the continuous mode of the signal generator.
+"""This module demonstrates the continuous mode of the signal generator.
 
 In continuous mode, the generator continuously generates the selected signal
 until the generator is stopped. Starting the generator is done using the
 function "start()". Stopping the generator is done using the function "stop()".
 The current period of the signal that is being generated is not finished, the
-output will go immediately to the selected Offset. In order to visualize the
+output will go immediately to the selected offset. In order to visualize the
 generated signal you need to connect the output of the handyscope with an input
 from an external oscilloscope.
 """
-from handyscope import Generator
 import time
+
+from handyscope import Generator
+
 
 gen = Generator("HS5")  # Initialize HS5 generator device
 
 gen.mode = "continuous"
 gen.signal_type = "sine"
 gen.amplitude = 2  # 2 V
-gen.freq = 1e6  # 1e6 Hz
+gen.freq = 50  # 50 Hz
 gen.offset = 1  # 1 V
 
 gen.is_out_on = True
 
 gen.start()
-time.sleep(10)  # 10 seconds to generate the signal
+time.sleep(1)  # 1 second to generate the signal
 
 gen.stop()
-time.sleep(2)  # Wait 2 seconds before python script terminates
+# Output offset for another second by keeping python script running
+time.sleep(1)

--- a/examples/generator_continuous.py
+++ b/examples/generator_continuous.py
@@ -1,0 +1,28 @@
+"""This Module demonstrates the continuous mode of the signal generator.
+
+In continuous mode, the generator continuously generates the selected signal
+until the generator is stopped. Starting the generator is done using the
+function "start()". Stopping the generator is done using the function "stop()".
+The current period of the signal that is being generated is not finished, the
+output will go immediately to the selected Offset. In order to visualize the
+generated signal you need to connect the output of the handyscope with an input
+from an external oscilloscope.
+"""
+from handyscope import Generator
+import time
+
+gen = Generator("HS5")  # Initialize HS5 generator device
+
+gen.mode = "continuous"
+gen.signal_type = "sine"
+gen.amplitude = 2  # 2 V
+gen.freq = 1e6  # 1e6 Hz
+gen.offset = 1  # 1 V
+
+gen.is_out_on = True
+
+gen.start()
+time.sleep(10)  # 10 seconds to generate the signal
+
+gen.stop()
+time.sleep(2)  # Wait 2 seconds before python script terminates

--- a/examples/oscilloscope_generator_burst.py
+++ b/examples/oscilloscope_generator_burst.py
@@ -1,25 +1,28 @@
-"""This Module demonstrates the oscilloscope for burst signals.
+"""This module demonstrates the oscilloscope for burst signals.
 
 A burst signal is generated to demonstrate how this signal can be recorded
-using the build in oscilloscope of the device. Therefore common settings are
-made. It is important to note that channel 1 is used and that you need to
-connect channel 1 to the signal generator of the device. The user can observe
-the signal using the internal oscilloscope by having a look at the given plot.
+using the built-in oscilloscope of the device.
+
+It is important to note that channel 1 is used and that you need to connect
+channel 1 to the signal generator of the device. You can observe the signal
+using the internal oscilloscope by having a look at the given plot.
 Additionaly an external oscilloscope can be used as well.
 """
+import time
+
+import matplotlib.pyplot as plt
+
 from handyscope import Generator
 from handyscope import Oscilloscope
-import matplotlib.pyplot as plt
-import numpy as np
-import time
+
 
 gen = Generator("HS5")  # Initialize HS5 generator device
 
 gen.mode = "burst count"
 gen.signal_type = "sine"
 gen.amplitude = 2  # 2 V
-gen.freq = 10  # 10 Hz
-gen.burst_cnt = 50  # Duration of signal is equivalent to 5 seconds
+gen.freq = 1e6  # 1 MHz
+gen.burst_cnt = 10  # Duration of signal is equivalent to 10 microseconds
 gen.is_out_on = True
 
 osc = Oscilloscope("HS5")  # Initialize HS5 oscilloscope device
@@ -31,14 +34,15 @@ osc.channels[0].is_trig_enabled = True
 osc.channels[0].trig_kind = "rising"
 osc.channels[0].trig_lvl_mode = "absolute"
 osc.channels[0].trig_lvl = (1,)  # 1 V (Must be given as tuple)
-osc.channels[0].range = 4  # 4 V (Possible values in V: 2, 4, 8, 20, 40, 80)
+osc.channels[0].range = 4  # 4 V
+osc.pre_sample_ratio = 0.1
 
-osc.sample_freq = 10 * gen.freq
-osc.record_length = int(10 * osc.sample_freq)  # Measure for 10 seconds
+osc.sample_freq = 20 * gen.freq
+osc.record_length = int(1e-4 * osc.sample_freq)  # Measure for 100 microseconds
 
 osc.start()  # Start measurement
 
-time.sleep(0.3)  # Delay
+time.sleep(0.3)  # Delay to ensure oscilloscope is armed
 gen.start()  # Start generator
 
 while not osc.is_data_ready:
@@ -47,11 +51,13 @@ while not osc.is_data_ready:
 gen.stop()
 
 data = osc.retrieve()[0]  # Data from channel 1
-t = np.arange(0, 10, 1 / osc.sample_freq) # Time array
+t = osc.time_vector
 
 plt.figure()
 plt.plot(t, data)
-plt.title("Example 2: Oscilloscope recording burst signal")
+plt.title("Burst signal recorded by oscilloscope")
 plt.xlabel("$t$ in s")
 plt.ylabel("$u$ in V")
+plt.grid()
+plt.autoscale(enable="True", axis="x", tight=True)
 plt.show()

--- a/examples/oscilloscope_generator_burst.py
+++ b/examples/oscilloscope_generator_burst.py
@@ -1,0 +1,57 @@
+"""This Module demonstrates the oscilloscope for burst signals.
+
+A burst signal is generated to demonstrate how this signal can be recorded
+using the build in oscilloscope of the device. Therefore common settings are
+made. It is important to note that channel 1 is used and that you need to
+connect channel 1 to the signal generator of the device. The user can observe
+the signal using the internal oscilloscope by having a look at the given plot.
+Additionaly an external oscilloscope can be used as well.
+"""
+from handyscope import Generator
+from handyscope import Oscilloscope
+import matplotlib.pyplot as plt
+import numpy as np
+import time
+
+gen = Generator("HS5")  # Initialize HS5 generator device
+
+gen.mode = "burst count"
+gen.signal_type = "sine"
+gen.amplitude = 2  # 2 V
+gen.freq = 10  # 10 Hz
+gen.burst_cnt = 50  # Duration of signal is equivalent to 5 seconds
+gen.is_out_on = True
+
+osc = Oscilloscope("HS5")  # Initialize HS5 oscilloscope device
+
+osc.trig_timeout = -1  # Disable trigger timeout
+
+osc.channels[0].is_enabled = True  # Enable channel 1
+osc.channels[0].is_trig_enabled = True
+osc.channels[0].trig_kind = "rising"
+osc.channels[0].trig_lvl_mode = "absolute"
+osc.channels[0].trig_lvl = (1,)  # 1 V (Must be given as tuple)
+osc.channels[0].range = 4  # 4 V (Possible values in V: 2, 4, 8, 20, 40, 80)
+
+osc.sample_freq = 10 * gen.freq
+osc.record_length = int(10 * osc.sample_freq)  # Measure for 10 seconds
+
+osc.start()  # Start measurement
+
+time.sleep(0.3)  # Delay
+gen.start()  # Start generator
+
+while not osc.is_data_ready:
+    time.sleep(0.1)
+
+gen.stop()
+
+data = osc.retrieve()[0]  # Data from channel 1
+t = np.arange(0, 10, 1 / osc.sample_freq) # Time array
+
+plt.figure()
+plt.plot(t, data)
+plt.title("Example 2: Oscilloscope recording burst signal")
+plt.xlabel("$t$ in s")
+plt.ylabel("$u$ in V")
+plt.show()

--- a/examples/oscilloscope_generator_continuous.py
+++ b/examples/oscilloscope_generator_continuous.py
@@ -1,0 +1,48 @@
+"""This Module demonstrates the oscilloscope for continuous signals.
+
+A continuous signal is generated to demonstrate how this signal can be recorded
+using the build in oscilloscope of the device. Therefore common settings are
+made. It is important to note that channel 1 is used and that you need to
+connect channel 1 to the signal generator of the device. The user can observe
+the signal using the internal oscilloscope by having a look at the given plot.
+Additionaly an external oscilloscope can be used as well.
+"""
+from handyscope import Generator
+from handyscope import Oscilloscope
+import matplotlib.pyplot as plt
+import numpy as np
+
+gen = Generator("HS5")  # Initialize HS5 generator device
+
+gen.mode = "continuous"
+gen.signal_type = "sine"
+gen.amplitude = 2  # 2 V
+gen.freq = 10  # 10 Hz
+gen.is_out_on = True
+
+osc = Oscilloscope("HS5")  # Initialize HS5 oscilloscope device
+
+osc.trig_timeout = -1  # Disable trigger timeout
+
+osc.channels[0].is_enabled = True  # Enable channel 1
+osc.channels[0].is_trig_enabled = True
+osc.channels[0].trig_kind = "rising"
+osc.channels[0].trig_lvl_mode = "absolute"
+osc.channels[0].trig_lvl = (1,)  # 1 V (Must be given as tuple)
+osc.channels[0].range = 4  # 4 V (Possible values in V: 2, 4, 8, 20, 40, 80) 
+
+osc.sample_freq = 10 * gen.freq
+osc.record_length = int(10 * osc.sample_freq)  # Measure for 10 seconds
+
+gen.start()
+data = osc.measure()[0]  # Data from channel 1
+gen.stop()
+
+t = np.arange(0, 10, 1 / osc.sample_freq) # Time array
+
+plt.figure()
+plt.plot(t, data)
+plt.title("Example 1: Oscilloscope recording continuous signal")
+plt.xlabel("$t$ in s")
+plt.ylabel("$u$ in V")
+plt.show()

--- a/examples/oscilloscope_generator_continuous.py
+++ b/examples/oscilloscope_generator_continuous.py
@@ -1,23 +1,25 @@
-"""This Module demonstrates the oscilloscope for continuous signals.
+"""This module demonstrates the oscilloscope for continuous signals.
 
 A continuous signal is generated to demonstrate how this signal can be recorded
-using the build in oscilloscope of the device. Therefore common settings are
-made. It is important to note that channel 1 is used and that you need to
-connect channel 1 to the signal generator of the device. The user can observe
-the signal using the internal oscilloscope by having a look at the given plot.
+using the build in oscilloscope of the device.
+
+It is important to note that channel 1 is used and that you need to connect
+channel 1 to the signal generator of the device. You can observe the signal
+using the internal oscilloscope by having a look at the given plot.
 Additionaly an external oscilloscope can be used as well.
 """
+import matplotlib.pyplot as plt
+
 from handyscope import Generator
 from handyscope import Oscilloscope
-import matplotlib.pyplot as plt
-import numpy as np
+
 
 gen = Generator("HS5")  # Initialize HS5 generator device
 
 gen.mode = "continuous"
 gen.signal_type = "sine"
 gen.amplitude = 2  # 2 V
-gen.freq = 10  # 10 Hz
+gen.freq = 1e6  # 1 MHz
 gen.is_out_on = True
 
 osc = Oscilloscope("HS5")  # Initialize HS5 oscilloscope device
@@ -29,20 +31,22 @@ osc.channels[0].is_trig_enabled = True
 osc.channels[0].trig_kind = "rising"
 osc.channels[0].trig_lvl_mode = "absolute"
 osc.channels[0].trig_lvl = (1,)  # 1 V (Must be given as tuple)
-osc.channels[0].range = 4  # 4 V (Possible values in V: 2, 4, 8, 20, 40, 80) 
+osc.channels[0].range = 4  # 4 V
 
-osc.sample_freq = 10 * gen.freq
-osc.record_length = int(10 * osc.sample_freq)  # Measure for 10 seconds
+osc.sample_freq = 20 * gen.freq
+osc.record_length = int(1e-4 * osc.sample_freq)  # Measure for 100 microseconds
 
 gen.start()
 data = osc.measure()[0]  # Data from channel 1
 gen.stop()
 
-t = np.arange(0, 10, 1 / osc.sample_freq) # Time array
+t = osc.time_vector
 
 plt.figure()
 plt.plot(t, data)
-plt.title("Example 1: Oscilloscope recording continuous signal")
+plt.title("Continuous signal recorded by oscilloscope")
 plt.xlabel("$t$ in s")
 plt.ylabel("$u$ in V")
+plt.grid()
+plt.autoscale(enable="True", axis="x", tight=True)
 plt.show()


### PR DESCRIPTION
This pull request adds example scripts that demonstrate how to use both the signal generator and oscilloscope functionalities of a Handyscope device. The examples show how to:

- Configure and start a signal generator to output a waveform.
- Set up the oscilloscope to capture the generated signal.
- Retrieve and optionally visualize the measured data.